### PR TITLE
Using use-client

### DIFF
--- a/src/api/ip.js
+++ b/src/api/ip.js
@@ -1,4 +1,4 @@
-
+"use client"
 
 const getIpData = async() => {
     try {


### PR DESCRIPTION
Added a 'use-client' keyword to ensure that the ip api is fetching the ip-address on the client-side instead of the server-side